### PR TITLE
PTRENG-6034 - partnership registry deprecation + helm charts updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All changes to the New Relic log analytics integration will be documented in this file.
 
+## [0.0.6] - June 6, 2024
+* [BREAKING] Adding deprecation notice for partnership-pts-observability.jfrog.io docker registry
+* FluentD sidecar version bumped to 4.3, to upgrade base image to bitnami/fluentd 1.16.5
+* Update FluentD sidecar helm charts to match recent changes in JFrog's official charts
+
 ## [0.5.0] - April 19, 2024
 
 * Fix fluentd regex to fetch correctly docker image and repo names

--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ Recommended installation for Kubernetes is to utilize the helm chart with the as
 | Artifactory HA | helm/artifactory-ha-values.yaml |
 | Xray           | helm/xray-values.yaml           |
 
+> [!WARNING]
+>
+> The old docker registry `partnership-pts-observability.jfrog.io`, which contains older versions of this integration is now deprecated. We'll keep the existing docker images on this old registry until August 1st, 2024. After that date, this registry will no longer be available. Please `helm upgrade` your JFrog kubernetes deployment in order to pull images as specified on the above helm value files, from the new `releases-pts-observability-fluentd.jfrog.io` registry. Please do so in order to avoid `ImagePullBackOff` errors in your deployment once this registry is gone.
+
 Add JFrog Helm repository
 
 ```bash

--- a/helm/artifactory-ha-values.yaml
+++ b/helm/artifactory-ha-values.yaml
@@ -2,7 +2,7 @@ installerInfo: '{ "productId": "OnPremObservability-Newrelic/2.0.0", "features":
 artifactory:
   customInitContainersBegin: |
     - name: "prepare-fluentd-conf-on-persistent-volume"
-      image: "{{ .Values.initContainerImage }}"
+      image:  {{ include "artifactory.getImageInfoByValue" (list . "initContainers") }}
       imagePullPolicy: "{{ .Values.artifactory.image.pullPolicy }}"
       command:
         - 'sh'
@@ -15,7 +15,7 @@ artifactory:
           name: volume
   customSidecarContainers: |
     - name: "artifactory-fluentd-sidecar"
-      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.2"
+      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.3"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"

--- a/helm/artifactory-values.yaml
+++ b/helm/artifactory-values.yaml
@@ -2,8 +2,7 @@ installerInfo: '{ "productId": "OnPremObservability-Newrelic/2.0.0", "features":
 artifactory:
   customInitContainersBegin: |
     - name: "download-fluentd-conf-on-persistent-volume"
-      image: "{{ .Values.initContainerImage }}"
-      image: "{{ .Values.initContainerImage }}"
+      image: {{ include "artifactory.getImageInfoByValue" (list . "initContainers") }}
       imagePullPolicy: "{{ .Values.artifactory.image.pullPolicy }}"
       command:
         - 'sh'
@@ -16,7 +15,7 @@ artifactory:
           name: artifactory-volume
   customSidecarContainers: |
     - name: "artifactory-fluentd-sidecar"
-      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.2"
+      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.3"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"

--- a/helm/xray-values.yaml
+++ b/helm/xray-values.yaml
@@ -15,7 +15,7 @@ rabbitmq:
 common:
   customInitContainersBegin: |
     - name: "prepare-fluentd-conf-on-persistent-volume"
-      image: "{{ .Values.initContainerImage }}"
+      image: {{ include "xray.getImageInfoByValue" (list . "initContainers") }}
       imagePullPolicy: "{{ .Values.imagePullPolicy }}"
       command:
         - 'sh'
@@ -28,7 +28,7 @@ common:
           name: data-volume
   customSidecarContainers: |
     - name: "xray-platform-fluentd-sidecar"
-      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.2"
+      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.3"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.xray.persistence.mountPath }}"


### PR DESCRIPTION
- FluentD sidecar init container helm chart changes
- Deprecation note for partnership docker registry
- upgrade sidecar to use bitnami/fluentd:1.16.5 as a base image