### PR TITLE
Upgrading fluentd sidecar to 4.5 & readme metrics update  & helm value file fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All changes to the New Relic log analytics integration will be documented in this file.
 
+## [0.0.7] - July 16, 2024
+* Fluentd sidecar version bumped to 4.5, to upgrade base image to bitnami/fluentd 1.17.0
+* Fixing fluent-plugin-jfrog-metrics issue (upgrading to 0.2.7) - resolving PTRENG-6234
+
 ## [0.0.6] - June 6, 2024
 * [BREAKING] Adding deprecation notice for partnership-pts-observability.jfrog.io docker registry
 * FluentD sidecar version bumped to 4.3, to upgrade base image to bitnami/fluentd 1.16.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All changes to the New Relic log analytics integration will be documented in thi
 ## [0.0.7] - July 16, 2024
 * Fluentd sidecar version bumped to 4.5, to upgrade base image to bitnami/fluentd 1.17.0
 * Fixing fluent-plugin-jfrog-metrics issue (upgrading to 0.2.7) - resolving PTRENG-6234
+* Fixing logs and metrics default New Relic uri in helm value files
 
 ## [0.0.6] - June 6, 2024
 * [BREAKING] Adding deprecation notice for partnership-pts-observability.jfrog.io docker registry

--- a/docker-build/Dockerfile
+++ b/docker-build/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for bitnami/fluentd sidecar image with all the necessary plugins for our log analytic providers
-FROM bitnami/fluentd:1.15.2
+FROM bitnami/fluentd:1.17.0
 LABEL maintainer="Partner Engineering <partner_support@jfrog.com>"
 
 ## Build time Arguments, short circuit them to ENV Variables so they are available at run time also

--- a/helm/artifactory-ha-values.yaml
+++ b/helm/artifactory-ha-values.yaml
@@ -15,7 +15,7 @@ artifactory:
           name: volume
   customSidecarContainers: |
     - name: "artifactory-fluentd-sidecar"
-      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.3"
+      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.5"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"
@@ -37,7 +37,7 @@ artifactory:
         - name: NEWRELIC_LICENSE_KEY
           value: {{ .Values.newrelic.license_key }}
         - name: FLUENTD_CONF
-          value: ../../../../{{ .Values.artifactory.persistence.mountPath }}/etc/fluentd/fluentd.conf
+          value: ../../../..{{ .Values.artifactory.persistence.mountPath }}/etc/fluentd/fluentd.conf
         - name: NEWRELIC_LOGS_URI
           value: {{ .Values.newrelic.logs_uri }}
         - name: NEWRELIC_METRICS_URI

--- a/helm/artifactory-ha-values.yaml
+++ b/helm/artifactory-ha-values.yaml
@@ -44,8 +44,8 @@ artifactory:
           value: {{ .Values.newrelic.metrics_uri }}
 newrelic:
   license_key: NEWRELIC_LICENSE_KEY
-  logs_uri: https://log-api.newrelic.com
-  metrics_uri: https://metrics-api.newrelic.com
+  logs_uri: https://log-api.newrelic.com/log/v1
+  metrics_uri: https://metric-api.newrelic.com/metric/v1
 jfrog:
   observability:
     jpd_url: JPD_URL

--- a/helm/artifactory-values.yaml
+++ b/helm/artifactory-values.yaml
@@ -15,7 +15,7 @@ artifactory:
           name: artifactory-volume
   customSidecarContainers: |
     - name: "artifactory-fluentd-sidecar"
-      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.3"
+      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.5"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"
@@ -37,7 +37,7 @@ artifactory:
         - name: NEWRELIC_LICENSE_KEY
           value: {{ .Values.newrelic.license_key }}
         - name: FLUENTD_CONF
-          value: ../../../../{{ .Values.artifactory.persistence.mountPath }}/etc/fluentd/fluentd.conf
+          value: ../../../..{{ .Values.artifactory.persistence.mountPath }}/etc/fluentd/fluentd.conf
         - name: NEWRELIC_LOGS_URI
           value: {{ .Values.newrelic.logs_uri }}
         - name: NEWRELIC_METRICS_URI

--- a/helm/artifactory-values.yaml
+++ b/helm/artifactory-values.yaml
@@ -44,8 +44,8 @@ artifactory:
           value: {{ .Values.newrelic.metrics_uri }}
 newrelic:
   license_key: NEWRELIC_LICENSE_KEY
-  logs_uri: https://log-api.newrelic.com
-  metrics_uri: https://metrics-api.newrelic.com
+  logs_uri: https://log-api.newrelic.com/log/v1
+  metrics_uri: https://metric-api.newrelic.com/metric/v1
 jfrog:
   observability:
     jpd_url: JPD_URL

--- a/helm/xray-values.yaml
+++ b/helm/xray-values.yaml
@@ -28,7 +28,7 @@ common:
           name: data-volume
   customSidecarContainers: |
     - name: "xray-platform-fluentd-sidecar"
-      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.3"
+      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.5"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.xray.persistence.mountPath }}"
@@ -37,7 +37,7 @@ common:
         - name: JF_PRODUCT_DATA_INTERNAL
           value: {{ .Values.xray.persistence.mountPath }}
         - name: FLUENTD_CONF
-          value: ../../../../{{ .Values.xray.persistence.mountPath }}/etc/fluentd/fluentd.conf
+          value: ../../../..{{ .Values.xray.persistence.mountPath }}/etc/fluentd/fluentd.conf
         - name: JPD_URL
           value: {{ .Values.jfrog.observability.jpd_url }}
         - name: JPD_ADMIN_USERNAME

--- a/helm/xray-values.yaml
+++ b/helm/xray-values.yaml
@@ -57,8 +57,8 @@ common:
           value: {{ .Values.newrelic.metrics_uri }}
 newrelic:
   license_key: NEWRELIC_LICENSE_KEY
-  logs_uri: https://log-api.newrelic.com
-  metrics_uri: https://metrics-api.newrelic.com
+  logs_uri: https://log-api.newrelic.com/log/v1
+  metrics_uri: https://metric-api.newrelic.com/metric/v1
 jfrog:
   observability:
     jpd_url: JPD_URL


### PR DESCRIPTION
* Release new version 4.5 & fix fluentd metrics plugin issue(resolving PTRENG-6234)

*  Fix metrics configuration in readme file (resolving PTRENG-6186)

* Fix New Relic logs and metrics URIs in helm value files