### PR TITLE
PTRENG-6513 - Upgrade FluentD sidecar to version 4.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All changes to the New Relic log analytics integration will be documented in this file.
 
+## [0.0.9] - November 7, 2024
+
+* FluentD sidecar image version bumped to 4.13, to reflect changes in `jfrog_siem` and `jfrog_send_metrics` FluentD plugins 
+
 ## [0.0.8] - August 19, 2024
 
 * FluentD sidecar image version bumped to 4.7, to upgrade base image to bitnami/fluentd 1.17.0

--- a/helm/artifactory-ha-values.yaml
+++ b/helm/artifactory-ha-values.yaml
@@ -18,7 +18,7 @@ artifactory:
           name: volume
   customSidecarContainers: |
     - name: "artifactory-fluentd-sidecar"
-      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.7"
+      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.13"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"

--- a/helm/artifactory-values.yaml
+++ b/helm/artifactory-values.yaml
@@ -18,7 +18,7 @@ artifactory:
           name: artifactory-volume
   customSidecarContainers: |
     - name: "artifactory-fluentd-sidecar"
-      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.7"
+      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.13"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"

--- a/helm/xray-values.yaml
+++ b/helm/xray-values.yaml
@@ -28,7 +28,7 @@ common:
           name: data-volume
   customSidecarContainers: |
     - name: "xray-platform-fluentd-sidecar"
-      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.7"
+      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.13"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.xray.persistence.mountPath }}"


### PR DESCRIPTION
Upgrade FluentD sidecar to version 4.13 to include changes made in `jfrog_siem` and `jfrog_metrics` FluentD plugins