### PR TITLE
JOBS-2090: Add RTFS metrics source in log-analytics-newrelic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All changes to the New Relic log analytics integration will be documented in thi
 
 ## [1.0.2] - April 2026
 
-* Added RTFS (Real-Time File Store) metrics collection support in Artifactory fluentd config (JOBS-1897)
+* Added RTFS (JFrog Artifactory Federation Service) metrics collection support in Artifactory fluentd config (JOBS-1897)
 * Requires fluent-plugin-jfrog-metrics >= 0.2.16
 
 ## [1.0.1] - March 18, 2025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All changes to the New Relic log analytics integration will be documented in this file.
 
+## [1.0.2] - April 2026
+
+* Added RTFS (Real-Time File Store) metrics collection support in Artifactory fluentd config (JOBS-1897)
+* Requires fluent-plugin-jfrog-metrics >= 0.2.16
+
 ## [1.0.1] - March 18, 2025
 
 * Update artifactory-ha helm values file

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Once this configuration is done and the application is restarted, metrics will b
 
 :bulb: Metrics are enabled by default in Xray.
 
-:bulb: **RTFS Metrics**: If your Artifactory deployment includes RTFS (Real-Time File Store), metrics are automatically collected from the `artifactory/service/rtfs/api/v1/metrics` endpoint. No additional configuration is required -- the fluentd config already includes an RTFS metrics source block that runs alongside the standard Artifactory metrics collection. Requires `fluent-plugin-jfrog-metrics` >= 0.2.16.
+:bulb: **RTFS Metrics**: If your Artifactory deployment includes RTFS (JFrog Artifactory Federation Service), metrics are automatically collected from the `rtfs/api/v1/metrics` endpoint. No additional configuration is required -- the fluentd config already includes an RTFS metrics source block that runs alongside the standard Artifactory metrics collection. Requires `fluent-plugin-jfrog-metrics` >= 0.2.16.
 
 For kubernetes based installs, openMetrics are enabled in the helm install commands listed below
 
@@ -431,7 +431,7 @@ JFrog Artifactory Dashboard is divided into three sections Application, Audit, R
 
 #### JFrog RTFS Metrics
 
-When RTFS is deployed as part of Artifactory, RTFS metrics are collected from `artifactory/service/rtfs/api/v1/metrics` and forwarded to New Relic with the `jfrog.rtfs` metric prefix. These metrics are available alongside standard Artifactory metrics in New Relic for monitoring RTFS-specific performance and health.
+When RTFS is deployed as part of Artifactory, RTFS metrics are collected from `rtfs/api/v1/metrics` and forwarded to New Relic with the `jfrog.rtfs` metric prefix. These metrics are available alongside standard Artifactory metrics in New Relic for monitoring RTFS-specific performance and health.
 
 ### Xray dashboard
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,10 @@ artifactory:
 
 Once this configuration is done and the application is restarted, metrics will be available in Open Metrics Format
 
-Metrics are enabled by default in Xray.
+:bulb: Metrics are enabled by default in Xray.
+
+:bulb: **RTFS Metrics**: If your Artifactory deployment includes RTFS (Real-Time File Store), metrics are automatically collected from the `artifactory/service/rtfs/api/v1/metrics` endpoint. No additional configuration is required -- the fluentd config already includes an RTFS metrics source block that runs alongside the standard Artifactory metrics collection. Requires `fluent-plugin-jfrog-metrics` >= 0.2.16.
+
 For kubernetes based installs, openMetrics are enabled in the helm install commands listed below
 
 ## Fluentd Installation
@@ -425,6 +428,10 @@ JFrog Artifactory Dashboard is divided into three sections Application, Audit, R
 * **Requests** - This section tracks HTTP response codes, top 10 IP addresses for uploads and downloads
 * **Docker** - To monitor Dockerhub pull requests users should have a Dockerhub account either paid or free. Free accounts allow up to 200 pull requests per 6 hour window. Various widgets have been added in the new Docker tab under Artifactory to help monitor your Dockerhub pull requests. An alert is also available to enable if desired that will allow you to send emails or add outbound webhooks through configuration to be notified when you exceed the configurable threshold
 * **Metrics** - To gain insights into the system performance, storage consumption, and connection statistics associated with JFrog Artifactory
+
+#### JFrog RTFS Metrics
+
+When RTFS is deployed as part of Artifactory, RTFS metrics are collected from `artifactory/service/rtfs/api/v1/metrics` and forwarded to New Relic with the `jfrog.rtfs` metric prefix. These metrics are available alongside standard Artifactory metrics in New Relic for monitoring RTFS-specific performance and health.
 
 ### Xray dashboard
 

--- a/fluent.conf.rt
+++ b/fluent.conf.rt
@@ -12,7 +12,24 @@
   common_jpd "#{ENV['COMMON_JPD']}"
   target_platform "NEWRELIC"
   # @log_level debug
-  # verify_ssl "#{ENV['DATADOG_VERIFY_SSL']}"
+  # verify_ssl "#{ENV['NEWRELIC_VERIFY_SSL']}"
+</source>
+# JFROG RTFS METRICS SOURCE
+# Requires fluent-plugin-jfrog-metrics >= 0.2.16 and RTFS enabled in the Artifactory deployment
+<source>
+  @type jfrog_metrics
+  @id metrics_http_rtfs
+  tag jfrog.metrics.rtfs
+  execution_interval 60s
+  request_timeout 30s
+  metric_prefix 'jfrog.rtfs'
+  jpd_url "#{ENV['JPD_URL']}"
+  username "#{ENV['JPD_ADMIN_USERNAME']}"
+  token "#{ENV['JPD_ADMIN_TOKEN']}"
+  common_jpd "#{ENV['COMMON_JPD']}"
+  target_platform "NEWRELIC"
+  # @log_level debug
+  # verify_ssl "#{ENV['NEWRELIC_VERIFY_SSL']}"
 </source>
 <match jfrog.metrics.**>
   @type jfrog_send_metrics


### PR DESCRIPTION
Add RTFS (Real-Time File Store) metrics collection support to the Artifactory fluentd config for New Relic. This enables scraping metrics from the RTFS endpoint at artifactory/service/rtfs/api/v1/metrics and forwarding them to New Relic with the jfrog.rtfs metric prefix.

Changes:
- Add RTFS source block in fluent.conf.rt with target_platform NEWRELIC
- Fix verify_ssl env var reference from DATADOG to NEWRELIC
- Update README with RTFS metrics documentation
- Update CHANGELOG with new version entry

Requires fluent-plugin-jfrog-metrics >= 0.2.16
Parent ticket: JOBS-1897

Testing Done:
**Container**: `jfrog-fluentd-newrelic-rt`

**Fluentd logs**:
```
[info]: [metrics_http_jfrt] Executing jfrog.rtfs metrics collection from: http://host.docker.internal:8082/rtfs/api/v1/metrics
[info]: [metrics_http_jfrt] jfrog.rtfs metrics were successfully collected from url: http://host.docker.internal:8082/rtfs/api/v1/metrics
[info]: Metrics were successfully sent to NewRelic
[info]: [metrics_http_jfrt] Timer task Execution successfully returned
```
**NRQL verification** (Account: 1873767 / JFrog-QA):
```sql
SELECT * FROM Metric WHERE metricName LIKE '%rtfs%' SINCE 60 minutes ago
```
Result: `jfrog.rtfs.test_metric` visible with value=42, type=gauge.

**90 `jfrog.artifactory.*` metrics** confirmed in New Relic via:
```sql
SELECT uniques(metricName) FROM Metric WHERE metricName LIKE 'jfrog%' SINCE 1 hour ago LIMIT 50
```
New Relic Query Builder UI
<img width="1722" height="1000" alt="Screenshot 2026-04-22 at 6 28 03 PM" src="https://github.com/user-attachments/assets/c4f529bc-55c8-4232-98b4-db93f56e2dd5" />

