### PR TITLE
JOBS-2125: Bump fluentd sidecar image from 4.17 to 4.19

### DIFF
--- a/helm/artifactory-ha-values.yaml
+++ b/helm/artifactory-ha-values.yaml
@@ -18,7 +18,7 @@ artifactory:
           name: volume
   customSidecarContainers: |
     - name: "artifactory-fluentd-sidecar"
-      image: "releases-docker.jfrog.io/fluentd:4.17"
+      image: "releases-docker.jfrog.io/fluentd:4.19"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"

--- a/helm/artifactory-values.yaml
+++ b/helm/artifactory-values.yaml
@@ -18,7 +18,7 @@ artifactory:
           name: artifactory-volume
   customSidecarContainers: |
     - name: "artifactory-fluentd-sidecar"
-      image: "releases-docker.jfrog.io/fluentd:4.17"
+      image: "releases-docker.jfrog.io/fluentd:4.19"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"

--- a/helm/xray-values.yaml
+++ b/helm/xray-values.yaml
@@ -28,7 +28,7 @@ common:
           name: data-volume
   customSidecarContainers: |
     - name: "xray-platform-fluentd-sidecar"
-      image: "releases-docker.jfrog.io/fluentd:4.17"
+      image: "releases-docker.jfrog.io/fluentd:4.19"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.xray.persistence.mountPath }}"


### PR DESCRIPTION
**Summary**

- Update fluentd sidecar Docker image tag from `4.17` to `4.19` in all Helm values files
- Image `4.19` includes `fluent-plugin-jfrog-metrics` gem v0.2.17 with RTFS metrics support and timestamp fix for NewRelic/Splunk parsers