### PR TITLE
JOBS-2475: Use released fluentd:4.21 image directly (Dockerfile + Helm)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All changes to the New Relic log analytics integration will be documented in this file.
 
+## [1.0.4] - June 2026
+
+* Fluentd sidecar image bumped to 4.21: now consumes the released image `releases-docker.jfrog.io/fluentd:4.21` directly (fluentd 1.19.2 on a hardened, CVE-refreshed base), remediating Critical/High CVEs in 4.19 (JOBS-2475)
+* `docker-build/Dockerfile` now builds `FROM releases-docker.jfrog.io/fluentd:4.21`, which already bundles curl and every required plugin (fluent-plugin-newrelic, -jfrog-siem, -jfrog-metrics, -jfrog-send-metrics, -concat), so the per-plugin `fluent-gem install` and `apt-get` steps were removed
+
 ## [1.0.3] - April 2026
 
 * Fix incorrect field name in access-security-audit log parsing: renamed `token_id` capture group to `trace_id` to match the actual log format documented at https://docs.jfrog.com/administration/docs/audit-trail-log (JOBS-2031)

--- a/README.md
+++ b/README.md
@@ -144,16 +144,21 @@ For NewRelic as the observability platform, execute these commands to setup the 
     NEWRELIC_LOGS_URI: This New Relic logs endpoint needs to be set if your New Relic instance is in the EU region (or if any other custom configuration is needed). It defaults to https://log-api.newrelic.com/log/v1
     NEWRELIC_METRICS_URI: This New Relic metrics endpoint needs to be set if your New Relic instance is in the EU region (or if any other custom configuration is needed). It defaults to https://metric-api.newrelic.com/metric/v1
 
-3. Execute 'docker run -it --name jfrog-fluentd-newrelic-rt -v <path_to_logs>:/var/opt/jfrog/artifactory --env-file docker.env <image_name>'
+3. Execute 'docker run -it --user root --name jfrog-fluentd-newrelic-rt -v <path_to_logs>:/var/opt/jfrog/artifactory --env-file docker.env <image_name>'
+
+    IMPORTANT (uid 999 log permissions): the container runs as the non-root 'fluent' user (uid 999) and must READ the mounted logs and WRITE .pos files into the mounted log directory. JFrog product logs are typically mode 640 (owned by the product user), which uid 999 cannot access by default, so without a fix the plain command fails immediately with "Errno::EACCES ... .pos" and the worker crash-loops (no logs or metrics are sent). The quickest fix is to add --user root (as shown above); for non-root alternatives see the IMPORTANT note right after this code block.
 
     The <path_to_logs> should be an absolute path where the Jfrog Artifactory Logs folder resides, i.e for an Docker based Artifactory Installation,  ex: /var/opt/jfrog/artifactory/var/logs on the docker host.
 
     Command example
 
-    'docker run -it --name jfrog-fluentd-newrelic-rt -v $JFROG_HOME/artifactory/var/:/var/opt/jfrog/artifactory --env-file docker.env jfrog/fluentd-newrelic-rt'
+    'docker run -it --user root --name jfrog-fluentd-newrelic-rt -v $JFROG_HOME/artifactory/var/:/var/opt/jfrog/artifactory --env-file docker.env jfrog/fluentd-newrelic-rt'
 
 
 ```
+
+> [!IMPORTANT]
+> The fluentd image runs as a non-root user (`fluent`, uid `999`). The container tails the Artifactory log files from the mounted directory and writes `.pos` (position) files next to them, so uid `999` must be able to **read** the mounted log files and **write** into the mounted log directory. JFrog product logs are typically owned by the product user (for example uid `1030`, directory mode `755`, files mode `640`), which uid `999` cannot access by default - fluentd then fails with `Errno::EACCES ... .pos` and the worker restarts in a loop. To avoid this, either run the container as root (`docker run --user root ...`), run it as the uid that owns the Artifactory logs (`--user <artifactory-uid>`), or make the mounted log directory readable and writable by uid `999`.
 
 ### Kubernetes Deployment with Helm
 

--- a/docker-build/Dockerfile
+++ b/docker-build/Dockerfile
@@ -1,5 +1,5 @@
-# Dockerfile for bitnami/fluentd sidecar image with all the necessary plugins for our log analytic providers
-FROM bitnami/fluentd:1.18.0
+# Dockerfile for fluentd sidecar image with all the necessary plugins for our log analytic providers
+FROM releases-docker.jfrog.io/fluentd:4.21
 LABEL maintainer="Partner Engineering <partner_support@jfrog.com>"
 
 ## Build time Arguments, short circuit them to ENV Variables so they are available at run time also
@@ -13,25 +13,13 @@ ENV TGT_PLATFORM=$TARGET
 
 USER root
 
-## Install JFrog Plugins
-RUN fluent-gem install fluent-plugin-newrelic
-RUN fluent-gem install fluent-plugin-jfrog-siem
-RUN fluent-gem install fluent-plugin-jfrog-metrics
-RUN fluent-gem install fluent-plugin-jfrog-send-metrics
-
-# Install prerequisites
-RUN apt-get update && apt-get install -y curl
-CMD /bin/bash
-
-
 ## Download Config Files
-RUN if [ "$SRC_PLATFORM" = "JFRT" ] ; then echo "Downloading the fluentd config file for $SRC_PLATFORM and $TGT_PLATFORM "; curl https://raw.githubusercontent.com/jfrog/log-analytics-newrelic/master/fluent.conf.rt -o /opt/bitnami/fluentd/conf/fluentd.conf; else echo "Not Downloading"; fi
-RUN if [ "$SRC_PLATFORM" = "JFXRAY" ] ; then echo "Downloading the fluentd config file for $SRC_PLATFORM and $TGT_PLATFORM "; curl https://raw.githubusercontent.com/jfrog/log-analytics-newrelic/master/fluent.conf.xray -o /opt/bitnami/fluentd/conf/fluentd.conf; else echo "Not Downloading"; fi
+## The released image releases-docker.jfrog.io/fluentd:4.21 already ships fluentd 1.19.2, curl, and every
+## plugin this integration needs (fluent-plugin-newrelic, -jfrog-siem, -jfrog-metrics, -jfrog-send-metrics,
+## -concat, ...), so no fluent-gem install or apt-get step is required here.
+RUN if [ "$SRC_PLATFORM" = "JFRT" ] ; then curl -fsSL https://raw.githubusercontent.com/jfrog/log-analytics-newrelic/main/fluent.conf.rt -o /fluentd/etc/fluent.conf; fi
+RUN if [ "$SRC_PLATFORM" = "JFXRAY" ] ; then curl -fsSL https://raw.githubusercontent.com/jfrog/log-analytics-newrelic/main/fluent.conf.xray -o /fluentd/etc/fluent.conf; fi
 
-
-ENTRYPOINT if [ "$TGT_PLATFORM" = "NEWRELIC" ] ; then cat /opt/bitnami/fluentd/conf/fluentd.conf; fluentd -v -c /opt/bitnami/fluentd/conf/fluentd.conf; fi
-
-
-USER 1001
+USER fluent
 
 STOPSIGNAL SIGTERM

--- a/helm/artifactory-ha-values.yaml
+++ b/helm/artifactory-ha-values.yaml
@@ -18,7 +18,7 @@ artifactory:
           name: volume
   customSidecarContainers: |
     - name: "artifactory-fluentd-sidecar"
-      image: "releases-docker.jfrog.io/fluentd:4.19"
+      image: "releases-docker.jfrog.io/fluentd:4.21"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"

--- a/helm/artifactory-values.yaml
+++ b/helm/artifactory-values.yaml
@@ -18,7 +18,7 @@ artifactory:
           name: artifactory-volume
   customSidecarContainers: |
     - name: "artifactory-fluentd-sidecar"
-      image: "releases-docker.jfrog.io/fluentd:4.19"
+      image: "releases-docker.jfrog.io/fluentd:4.21"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"

--- a/helm/xray-values.yaml
+++ b/helm/xray-values.yaml
@@ -28,7 +28,7 @@ common:
           name: data-volume
   customSidecarContainers: |
     - name: "xray-platform-fluentd-sidecar"
-      image: "releases-docker.jfrog.io/fluentd:4.19"
+      image: "releases-docker.jfrog.io/fluentd:4.21"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.xray.persistence.mountPath }}"


### PR DESCRIPTION
**Summary**
Consume the already-promoted public image `releases-docker.jfrog.io/fluentd:4.21` directly, instead of the private Echo base used on the superseded PRs.

- **docker-build/Dockerfile**: now `FROM releases-docker.jfrog.io/fluentd:4.21`; dropped the per-plugin `fluent-gem install` and the `apt-get install curl` steps. The released image already bundles fluentd 1.19.2, curl, and every required plugin, so "build-your-own-image" customers no longer need access to a private registry or a compiler.
- **helm/*-values.yaml**: bump the fluentd sidecar image `4.19 -> 4.21` (artifactory, artifactory-ha, xray).
- **README**: document the uid `999` log-dir permission requirement for the `docker run` path.
- **CHANGELOG**: add the 4.21 entry.

`releases-docker.jfrog.io/fluentd:4.21` is public (pullable with no auth) and is fluentd 1.19.2 on a hardened, CVE-refreshed base (remediates the Critical/High CVEs in 4.19).

Supersedes #27 (Echo-base Dockerfile) and #28 (Helm 4.20) — both will be closed in favor of this combined PR.

**Testing Done (released image, live E2E)**
- Promoted image checked: uid 999, fluentd 1.19.2, curl present, all 12 plugins baked in, no gcc/cc/make.
- Built this provider image FROM releases-docker.jfrog.io/fluentd:4.21 (no plugin/apt installs); `fluentd --dry-run` loads the config cleanly.
- Ran the sidecar on the promoted image against a live Artifactory: **"Metrics were successfully sent to NewRelic"** confirmed (account 1873767 JFrog-QA).
<img width="1722" height="999" alt="Screenshot 2026-06-24 at 9 48 08 AM" src="https://github.com/user-attachments/assets/610aaab4-488d-4bce-83d7-4539ef53db2b" />
